### PR TITLE
Harden MCP HTTP transport (auth, Host/Origin, body cap) + reusable CI test

### DIFF
--- a/.github/workflows/mcp-test.yml
+++ b/.github/workflows/mcp-test.yml
@@ -1,0 +1,135 @@
+name: mcp-test
+
+# Functional test for the MCP server (mcp/server.js) as it actually ships in
+# the image — without needing a logged-in Beeper account.
+#
+# The full smoke test (scripts/smoke-test.sh) needs an interactive Beeper
+# login via noVNC to reach (healthy), so it can't run unattended. This job
+# instead builds the real image and runs ONLY the MCP server standalone
+# (`--entrypoint node /opt/mcp/server.js`), then replays an HTTP assertion
+# matrix. Everything the MCP HTTP transport does *before* it calls the Beeper
+# API — protocol dispatch, tools/list, and the auth / Host / Origin / body
+# guards — is exercised here. Tool calls that hit Beeper are out of scope
+# (they need a real account; that's what smoke-test.sh covers manually).
+#
+# Triggers:
+#   - workflow_dispatch  -> run on demand ("trigger as needed")
+#   - pull_request       -> auto-run when MCP-relevant files change
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'mcp/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/mcp-test.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  mcp-guard-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # amd64 only: the MCP server is arch-independent Node logic, so there's
+      # no value in a QEMU arm64 build here. Load the image locally so we can
+      # `docker run` it. GHA cache is shared with release.yml's builds.
+      - name: Build image (amd64, load locally)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: beeperbox:mcp-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Start MCP server — open mode (no MCP_AUTH_TOKEN)
+        run: |
+          docker run -d --name mcp-open -p 23375:23375 \
+            --entrypoint node beeperbox:mcp-test /opt/mcp/server.js
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null -X POST http://127.0.0.1:23375 \
+                 -d '{"jsonrpc":"2.0","id":0,"method":"tools/list"}'; then
+              echo "MCP server ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "MCP server did not become ready"; docker logs mcp-open; exit 1
+
+      - name: Assert MCP contract — all 10 tools present
+        run: |
+          # jq is preinstalled on ubuntu-latest; walk result.tools[].name by
+          # structure (a substring grep would false-positive on tool names that
+          # appear inside another tool's description).
+          names=$(curl -s -X POST http://127.0.0.1:23375 \
+            -H 'Content-Type: application/json' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
+            | jq -r '.result.tools[].name')
+          fail=0
+          for t in list_accounts list_inbox list_unread get_chat read_chat \
+                   search_messages send_message note_to_self react_to_message archive_chat; do
+            if echo "$names" | grep -qx "$t"; then echo "PASS: $t present"; else echo "FAIL: $t missing"; fail=1; fi
+          done
+          exit $fail
+
+      - name: Assert hardening guard matrix — open mode
+        run: |
+          U=http://127.0.0.1:23375
+          fail=0
+          assert() { # desc expected actual
+            if [ "$2" = "$3" ]; then echo "PASS: $1 ($3)"; else echo "FAIL: $1 — expected $2 got $3"; fail=1; fi
+          }
+          code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+          assert "no-token localhost tools/list -> 200 (back-compat)" 200 \
+            "$(code -X POST $U -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
+          assert "cross-origin (bad Origin) -> 403" 403 \
+            "$(code -X POST $U -H 'Origin: https://evil.example' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
+          assert "DNS-rebind (bad Host) -> 403" 403 \
+            "$(code -X POST $U -H 'Host: evil.example' -d '{"jsonrpc":"2.0","id":4,"method":"tools/list"}')"
+          assert "allowed Origin (localhost:3000) -> 200" 200 \
+            "$(code -X POST $U -H 'Origin: http://localhost:3000' -d '{"jsonrpc":"2.0","id":5,"method":"tools/list"}')"
+          { printf '{"jsonrpc":"2.0","id":6,"method":"tools/list","pad":"'; head -c 12000000 /dev/zero | tr '\0' 'A'; printf '"}'; } > /tmp/big.json
+          assert "12MB body -> 413 (body cap)" 413 \
+            "$(code -X POST $U -H 'Content-Type: application/json' --data-binary @/tmp/big.json)"
+          exit $fail
+
+      - name: Start MCP server — auth mode (MCP_AUTH_TOKEN set)
+        run: |
+          docker run -d --name mcp-auth -p 23376:23375 \
+            -e MCP_AUTH_TOKEN=ci-secret \
+            --entrypoint node beeperbox:mcp-test /opt/mcp/server.js
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null -X POST http://127.0.0.1:23376 \
+                 -H 'Authorization: Bearer ci-secret' \
+                 -d '{"jsonrpc":"2.0","id":0,"method":"tools/list"}'; then
+              echo "auth-mode MCP server ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "auth-mode MCP server did not become ready"; docker logs mcp-auth; exit 1
+
+      - name: Assert bearer-token enforcement
+        run: |
+          U=http://127.0.0.1:23376
+          fail=0
+          assert() { if [ "$2" = "$3" ]; then echo "PASS: $1 ($3)"; else echo "FAIL: $1 — expected $2 got $3"; fail=1; fi; }
+          code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+          assert "no auth header -> 401" 401 \
+            "$(code -X POST $U -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')"
+          assert "wrong token -> 401" 401 \
+            "$(code -X POST $U -H 'Authorization: Bearer nope' -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
+          assert "correct token -> 200" 200 \
+            "$(code -X POST $U -H 'Authorization: Bearer ci-secret' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
+          exit $fail
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          echo "=== mcp-open ==="; docker logs mcp-open 2>&1 | tail -50 || true
+          echo "=== mcp-auth ==="; docker logs mcp-auth 2>&1 | tail -50 || true

--- a/.github/workflows/mcp-test.yml
+++ b/.github/workflows/mcp-test.yml
@@ -31,16 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # amd64 only: the MCP server is arch-independent Node logic, so there's
       # no value in a QEMU arm64 build here. Load the image locally so we can
       # `docker run` it. GHA cache is shared with release.yml's builds.
       - name: Build image (amd64, load locally)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,23 +56,23 @@ jobs:
 
       - name: Checkout
         if: steps.ref.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
       - name: Set up QEMU
         if: steps.ref.outputs.skip != 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
         if: steps.ref.outputs.skip != 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
         if: steps.ref.outputs.skip != 'true'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -81,7 +81,7 @@ jobs:
       - name: Compute image tags
         if: steps.ref.outputs.skip != 'true'
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/beeperbox
           tags: |
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build and push
         if: steps.ref.outputs.skip != 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -109,18 +109,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -133,13 +133,13 @@ jobs:
       # :edge needs the same.
       - name: Compute OCI labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/beeperbox
           tags: type=raw,value=edge
 
       - name: Build and push :edge
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,24 @@ Published tags on GHCR: `:X.Y.Z` (exact, immutable), `:X.Y` (rolling within a mi
 
 ## [Unreleased]
 
+### Security
+- **MCP HTTP transport gains optional bearer auth + always-on DNS-rebinding protection.** The HTTP transport on `:23375` previously executed any well-formed JSON-RPC request from anyone who could reach the port, with the user's `BEEPER_TOKEN` — the only thing standing between a caller and read/send across every connected network was the `127.0.0.1:` publish in `docker-compose.yml`. Two guards now run on every HTTP request (stdio transport is local-only and unaffected):
+  - **`Origin` / `Host` validation** (always on). A `Host` header outside the allowlist (`localhost`, `127.0.0.1`, `::1`, `[::1]` by default) is rejected `403` — this is the DNS-rebinding defense, since a rebound browser request carries the attacker's domain as `Host`. A cross-origin browser request (any `Origin` outside the allowlist) is likewise rejected `403`. Native clients (curl, MCP runtimes) send no `Origin` and a loopback `Host`, so they are unaffected. Set `MCP_ALLOWED_HOSTS` (comma-separated) when terminating a reverse proxy in front.
+  - **Bearer token** (opt-in). Set `MCP_AUTH_TOKEN` and every HTTP request must carry `Authorization: Bearer <token>` or get `401`. Left unset, the transport stays open for back-compat and relies on the loopback publish.
+  - **Why the listener still binds `0.0.0.0`:** Docker published ports DNAT to the container's interface — a process bound to `127.0.0.1` *inside* the container is unreachable through `127.0.0.1:23375:23375`. Binding loopback would silently break MCP access, so the bind is deliberately unchanged; auth + Host/Origin checks are the defense, not the bind address. (An earlier proposed "default to loopback bind" fix was rejected after empirically confirming it breaks the published port.)
+- **Request body cap on the MCP HTTP transport.** A POST body now aborts with `413` once it exceeds `MCP_MAX_BODY` bytes (default 1 MiB) instead of buffering unbounded into memory — closes a trivial memory-exhaustion vector (a 12 MB body previously returned `200` after fully buffering).
+
+### Added
+- Three MCP HTTP transport env vars, all optional and back-compat (unset = prior behavior): `MCP_AUTH_TOKEN` (require a bearer token), `MCP_ALLOWED_HOSTS` (Host/Origin allowlist for reverse-proxy deployments), `MCP_MAX_BODY` (request body cap in bytes). Plumbed through `docker-compose.yml`. Startup banner now prints the auth posture (`OPEN` vs `required`) and the active allowed-hosts list.
+
+### Verified
+- Validated against the running server (`node mcp/server.js`) with a live curl matrix, before/after: unauthenticated `tools/list` → served the full registry **before**, now still `200` when no token is set (back-compat / smoke-test path preserved); `Origin: https://evil.example` → `403`; `Host: evil.example` → `403`; `Origin: http://localhost:3000` → `200`; 12 MB body → `413` (was `200`); with `MCP_AUTH_TOKEN` set, missing/wrong token → `401`, correct token → `200`. Empty `MCP_ALLOWED_HOSTS` (as Compose passes when unset) correctly falls back to the loopback default.
+- **Not yet exercised in a built container / CI** — these are pure `server.js` logic changes covered by the local HTTP matrix above; the existing `scripts/smoke-test.sh` only probes unauthenticated `tools/list` (still passes) and the CI build doesn't run the MCP server functionally.
+
+### Still open (validated, not fixed)
+- **VNC has no password** (`entrypoint.sh:16`, `x11vnc … -nopw`). Real finding, deliberately not patched in this pass: the fix needs the container's X stack booted to verify, and a botched `-rfbauth` change risks locking out the one-time noVNC login. Tracked for a follow-up that can be tested end-to-end.
+- **Beeper AppImage fetched at build with no checksum/signature** (`Dockerfile`) — supply-chain note; deferred.
+
 ### Planned
 - Whatever the first real user issue asks for.
 

--- a/beeperbox.context.md
+++ b/beeperbox.context.md
@@ -287,6 +287,18 @@ Tool errors are returned as JSON-RPC error objects, not thrown. The LLM should r
 - **One container, one Beeper account, any number of tokens.** Each token can have its own scope (read-only or read + write), and you can revoke them individually from Beeper Desktop's Approved Connections panel.
 - Token creation: **Settings → Developers → Approved Connections → +** with `expiry: never`. See [docs/GUIDE.md](docs/GUIDE.md) for the full UI walkthrough.
 
+### MCP HTTP transport hardening
+
+`BEEPER_TOKEN` authenticates beeperbox *to Beeper* — it is **not** a credential callers present to the MCP HTTP transport. By default the HTTP transport on `:23375` accepts any well-formed request and relies on the `127.0.0.1` publish to keep it local. Three optional env vars harden that surface (all unset = prior behavior; the stdio transport is local-only and unaffected):
+
+| Env var | Effect | Default |
+|---|---|---|
+| `MCP_AUTH_TOKEN` | When set, every HTTP request must send `Authorization: Bearer <token>` or get `401`. | unset (open) |
+| `MCP_ALLOWED_HOSTS` | Comma-separated `Host`/`Origin` allowlist. Blocks DNS-rebinding (`403` on a non-allowlisted `Host`) and cross-origin browser calls (`403` on a non-allowlisted `Origin`). Set this to your hostname when running behind a reverse proxy. | `localhost,127.0.0.1,::1,[::1]` |
+| `MCP_MAX_BODY` | Max request body bytes; larger bodies abort `413`. | `1048576` (1 MiB) |
+
+The listener stays bound to `0.0.0.0` inside the container on purpose — a Docker published port is unreachable if the in-container process binds `127.0.0.1`. Auth + Host/Origin validation are the defense, not the bind address. For an agent that reaches the HTTP transport across hosts, set `MCP_AUTH_TOKEN` and send it as a bearer header.
+
 ### Read-only vs read-write tokens
 
 Beeper's token creation UI has an **"Allow sensitive actions"** toggle that gates write operations — you do not need a special beeperbox flag for this, the scope is enforced inside Beeper Desktop itself.
@@ -414,7 +426,7 @@ No N+1 chat fetches — search returns the chat metadata inline.
 |---|---|---|
 | **Default?** | Yes — always on via entrypoint | No — on demand |
 | **Where server lives** | Container background process on port 23375 | Spawned per-client via `docker exec -i` |
-| **Auth** | Shared `BEEPER_TOKEN` env | Same (inherited from container) |
+| **Auth** | Optional `MCP_AUTH_TOKEN` bearer + Host/Origin allowlist (see Auth model) | Local-only; inherits container env |
 | **Multi-client** | Many concurrent clients fine | One server per client process |
 | **Works across hosts** | Yes (expose the port) | No (requires `docker exec`) |
 | **Latency** | ~2ms local loopback | ~50ms process spawn + steady-state low |
@@ -431,7 +443,7 @@ beeperbox v0.4.x is a POC → early product. Real-world usage notes:
 - **No message delivery guarantees.** `send_message` returns a `pendingMessageID` immediately — actual delivery depends on the bridge. Poll `read_chat` or wait a few seconds before reacting to assume success.
 - **Persistent login.** The container's `/root/.config` volume holds the Beeper Desktop session. Back it up if you care about not re-logging in.
 - **Restart behavior.** The compose file sets `restart: unless-stopped` + a healthcheck that probes through the socat forwarder. Process death triggers restart immediately; API hangs are caught by the healthcheck within ~100s.
-- **Security.** Published ports are bound to `127.0.0.1` only by default. For remote access use SSH tunneling, Tailscale/Wireguard, or a TLS reverse proxy with auth. See [docs/GUIDE.md](docs/GUIDE.md) for patterns.
+- **Security.** Published ports are bound to `127.0.0.1` only by default. For remote access use SSH tunneling, Tailscale/Wireguard, or a TLS reverse proxy with auth. The MCP HTTP transport additionally validates `Host`/`Origin` (DNS-rebinding defense, always on) and can require a bearer token via `MCP_AUTH_TOKEN` — set it before exposing `:23375` beyond loopback. noVNC (`:6080`) still has no password and must stay loopback-only. See [docs/GUIDE.md](docs/GUIDE.md) for patterns.
 
 ## Version compatibility
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,15 @@ services:
       # raw API on :23373 is reachable (and even that needs the token
       # for everything except /v1/info).
       BEEPER_TOKEN: ${BEEPER_TOKEN:-}
+      # Optional bearer token for the MCP HTTP transport (:23375). When set,
+      # every MCP HTTP request must send `Authorization: Bearer <token>`.
+      # Leave empty to keep the transport open and rely on the loopback
+      # publish above. The stdio transport (docker exec -i … --stdio) is
+      # local-only and unaffected. Host/Origin are always validated against
+      # loopback to block DNS-rebinding; set MCP_ALLOWED_HOSTS for a reverse
+      # proxy in front (e.g. MCP_ALLOWED_HOSTS=mcp.example.com).
+      MCP_AUTH_TOKEN: ${MCP_AUTH_TOKEN:-}
+      MCP_ALLOWED_HOSTS: ${MCP_ALLOWED_HOSTS:-}
     volumes:
       - beeperbox_config:/root/.config
     shm_size: '256m'

--- a/docs/PRD-mcp-http-hardening.md
+++ b/docs/PRD-mcp-http-hardening.md
@@ -1,0 +1,58 @@
+# PRD — MCP HTTP Transport Hardening
+
+> Status: implemented (code), pending container/CI functional test and release tagging.
+> Scope: `mcp/server.js`, `docker-compose.yml`. No changes to the MCP tool surface, schemas, ports, or default behavior.
+
+## Problem
+
+The MCP HTTP transport on `:23375` executes any well-formed JSON-RPC request from anyone who can reach the port, using the container's `BEEPER_TOKEN`. The only control was the `127.0.0.1:` publish in `docker-compose.yml` — a single load-bearing layer that the compose comments themselves invite users to remove ("To expose publicly … drop the `127.0.0.1` prefix"). Three concrete weaknesses were confirmed empirically against the running server:
+
+1. **No authentication (H1).** Unauthenticated `tools/list` returned the full registry; unauthenticated `tools/call` reached dispatch and only failed *inside* the handler at the upstream call — i.e., with a real token it would have read/sent across every connected network.
+2. **No `Origin`/`Host` validation (H2).** A cross-origin browser request (`text/plain` body = no CORS preflight) was parsed and dispatched; a DNS-rebinding attack could then read responses. The server accepted any `Origin` and any `Host`.
+3. **Unbounded request body (M1).** A 12 MB POST returned `200` after fully buffering into memory — a trivial memory-exhaustion vector.
+
+## Goals
+
+- Make the HTTP transport safe to expose beyond loopback **without** breaking the documented loopback-publish or reverse-proxy deployments.
+- Close the browser-driven attack surface (DNS rebinding / cross-origin) **by default**, with no configuration required.
+- Bound request memory.
+- Zero breaking change: unset configuration ⇒ identical prior behavior; stdio transport untouched; `smoke-test.sh` still passes.
+
+## Non-goals / explicitly rejected
+
+- **Binding the listener to `127.0.0.1`.** Rejected after empirical confirmation that a process bound to loopback *inside* a container is unreachable through a Docker published port (`127.0.0.1:23375:23375` DNATs to the container interface). The bind stays `0.0.0.0`; auth + Host/Origin checks are the defense.
+- **Binding the socat API forwarder to loopback.** Same Docker-publish constraint (`23380` is the published API port). No change.
+- **VNC password (H3)** and **AppImage checksum pinning (M2)** — real findings, deferred (see Open items).
+
+## Requirements
+
+| ID | Requirement |
+|----|-------------|
+| R1 | `MCP_AUTH_TOKEN` (optional): when set, every HTTP request must send `Authorization: Bearer <token>`; otherwise `401`. Unset ⇒ no auth enforced. |
+| R2 | `Host` header validated against an allowlist on every request; non-match ⇒ `403`. (DNS-rebinding defense.) Always on. |
+| R3 | `Origin` header, when present, validated against the same allowlist; non-match ⇒ `403`. Absent `Origin` (native clients) ⇒ allowed. |
+| R4 | `MCP_ALLOWED_HOSTS` (optional, comma-separated) overrides the allowlist; default `localhost,127.0.0.1,::1,[::1]`. Empty string ⇒ default. |
+| R5 | `MCP_MAX_BODY` (optional, bytes, default 1 MiB): request body exceeding the cap aborts `413` and the socket is destroyed; no double-response. |
+| R6 | stdio transport unchanged; guards apply to HTTP only. |
+| R7 | Env vars plumbed through `docker-compose.yml` (Compose only forwards listed vars into the container). |
+| R8 | Startup banner reflects auth posture and active allowlist. |
+
+## Acceptance criteria (verified locally, before/after)
+
+| Case | Expected | Result |
+|------|----------|--------|
+| No token, plain localhost `tools/list` (smoke-test path) | `200` + registry | ✅ |
+| `Origin: https://evil.example` | `403` | ✅ |
+| `Host: evil.example` (DNS-rebind) | `403` | ✅ |
+| `Origin: http://localhost:3000` | `200` | ✅ |
+| 12 MB body | `413` (was `200`) | ✅ |
+| `MCP_AUTH_TOKEN` set, no auth header | `401` | ✅ |
+| `MCP_AUTH_TOKEN` set, wrong token | `401` | ✅ |
+| `MCP_AUTH_TOKEN` set, correct token | `200` | ✅ |
+| Empty `MCP_ALLOWED_HOSTS` env | falls back to loopback default | ✅ |
+
+## Open items / follow-up
+
+- **H3 — VNC `-nopw`:** add `x11vnc -rfbauth` from an env-supplied password; requires booting the container's X stack to verify the noVNC login flow before merging.
+- **M2 — AppImage integrity:** pin/verify a checksum or signature for the Beeper Desktop download, or document the trust assumption.
+- **CI functional test:** the existing build job only assembles the image and the smoke test needs an interactive Beeper login. A standalone job that runs `node /opt/mcp/server.js` in the built image and replays the guard matrix above would cover these changes in CI without a Beeper account.

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -11,6 +11,63 @@ const PORT = parseInt(process.env.MCP_PORT || '23375', 10);
 const BEEPER_API = process.env.BEEPER_API || 'http://127.0.0.1:23373';
 const BEEPER_TOKEN = process.env.BEEPER_TOKEN || '';
 
+// ─── http transport hardening ─────────────────────────────────────
+// The HTTP transport is the network-exposed surface (stdio is local-only).
+// Three guards, all configurable so they don't break the documented
+// loopback publish or a reverse-proxy deployment:
+//   MCP_AUTH_TOKEN    — if set, every HTTP request must send
+//                       `Authorization: Bearer <token>`; unset = open
+//                       (back-compat; relies on the loopback publish).
+//   MCP_ALLOWED_HOSTS — Host/Origin allowlist (comma-separated). Blocks
+//                       DNS-rebinding and cross-origin browser access.
+//                       Defaults to loopback; set it for reverse proxies.
+//   MCP_MAX_BODY      — max request body bytes (default 1 MiB) so a large
+//                       POST can't grow the in-memory buffer unbounded.
+// The listener stays bound to 0.0.0.0 ON PURPOSE: a Docker published port
+// is unreachable if the in-container process binds 127.0.0.1, so loopback
+// binding here would break `127.0.0.1:23375:23375`. Auth + Host/Origin
+// checks are the defense, not the bind address.
+const MCP_AUTH_TOKEN = process.env.MCP_AUTH_TOKEN || '';
+const MCP_ALLOWED_HOSTS = new Set(
+  (process.env.MCP_ALLOWED_HOSTS || 'localhost,127.0.0.1,::1,[::1]')
+    .split(',').map((s) => s.trim().toLowerCase()).filter(Boolean),
+);
+const MCP_MAX_BODY = parseInt(process.env.MCP_MAX_BODY || String(1024 * 1024), 10);
+
+// Strip the port from a Host header value ("127.0.0.1:23375" -> "127.0.0.1",
+// "[::1]:23375" -> "[::1]").
+function hostFromHeader(value) {
+  if (!value) return '';
+  const h = value.trim().toLowerCase();
+  if (h.startsWith('[')) return h.slice(0, h.indexOf(']') + 1) || h;
+  const c = h.indexOf(':');
+  return c >= 0 ? h.slice(0, c) : h;
+}
+
+// Returns null when the request may proceed, else { status, message }.
+function httpGuard(req) {
+  // DNS-rebinding guard: the browser sends the attacker's domain as Host.
+  const host = hostFromHeader(req.headers.host);
+  if (host && !MCP_ALLOWED_HOSTS.has(host)) {
+    return { status: 403, message: `host not allowed: ${host}` };
+  }
+  // Cross-origin browser guard: native clients (curl, MCP runtimes) send no
+  // Origin, so this only ever rejects browser-initiated cross-site requests.
+  const origin = req.headers.origin;
+  if (origin) {
+    let oh;
+    try { oh = new URL(origin).hostname.toLowerCase(); } catch { oh = null; }
+    if (!oh || !(MCP_ALLOWED_HOSTS.has(oh) || MCP_ALLOWED_HOSTS.has(`[${oh}]`))) {
+      return { status: 403, message: `origin not allowed: ${origin}` };
+    }
+  }
+  // Bearer-token guard: only enforced when a token is configured.
+  if (MCP_AUTH_TOKEN && req.headers.authorization !== `Bearer ${MCP_AUTH_TOKEN}`) {
+    return { status: 401, message: 'unauthorized' };
+  }
+  return null;
+}
+
 // ─── beeper api helper ────────────────────────────────────────────
 
 async function beeperFetch(path, opts = {}) {
@@ -521,9 +578,27 @@ function startHttpTransport() {
       return;
     }
 
+    const denied = httpGuard(req);
+    if (denied) {
+      res.writeHead(denied.status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: denied.message } }));
+      return;
+    }
+
     let body = '';
-    req.on('data', (chunk) => { body += chunk; });
+    let aborted = false;
+    req.on('data', (chunk) => {
+      if (aborted) return;
+      body += chunk;
+      if (body.length > MCP_MAX_BODY) {
+        aborted = true;
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: `request body exceeds ${MCP_MAX_BODY} bytes` } }));
+        req.destroy();
+      }
+    });
     req.on('end', async () => {
+      if (aborted) return;
       let parsed;
       try {
         parsed = JSON.parse(body);
@@ -547,6 +622,8 @@ function startHttpTransport() {
     console.log(`[beeperbox-mcp] listening on http://0.0.0.0:${PORT}`);
     console.log(`[beeperbox-mcp] beeper api: ${BEEPER_API}`);
     console.log(`[beeperbox-mcp] beeper token: ${BEEPER_TOKEN ? 'set' : 'NOT SET (set BEEPER_TOKEN env var)'}`);
+    console.log(`[beeperbox-mcp] http auth: ${MCP_AUTH_TOKEN ? 'required (MCP_AUTH_TOKEN set)' : 'OPEN — set MCP_AUTH_TOKEN to require a bearer token'}`);
+    console.log(`[beeperbox-mcp] allowed hosts: ${[...MCP_ALLOWED_HOSTS].join(', ')}`);
   });
 }
 


### PR DESCRIPTION
## What

Hardens the MCP HTTP transport (`:23375`) and adds a **reusable, on-demand CI test** for MCP server changes.

### Findings addressed (all validated empirically against the running server)
- **No auth + `0.0.0.0` bind (H1):** unauthenticated `tools/list` served the full registry; unauth `tools/call` reached dispatch with the container's `BEEPER_TOKEN`. Only control was the loopback publish.
- **No `Origin`/`Host` validation (H2):** a cross-origin `text/plain` POST (no CORS preflight) was parsed and dispatched → DNS-rebinding / CSRF-to-localhost.
- **Unbounded body (M1):** a 12 MB POST returned `200` after fully buffering.

### Changes (`mcp/server.js`, `docker-compose.yml`)
- **Host/Origin allowlist** (always on) → `403` on DNS-rebind / cross-origin. Native clients (no `Origin`, loopback `Host`) unaffected. Override with `MCP_ALLOWED_HOSTS` for reverse proxies.
- **Bearer token** (opt-in) via `MCP_AUTH_TOKEN` → `401` without it; **unset = open (back-compat)**.
- **Body cap** via `MCP_MAX_BODY` (default 1 MiB) → `413`.
- Listener **stays `0.0.0.0`** on purpose — a Docker published port is unreachable if the in-container process binds `127.0.0.1`. (A "bind loopback" fix was proposed, stress-tested, and **rejected** for breaking `127.0.0.1:23375:23375`.)

### CI (`​.github/workflows/mcp-test.yml`)
Reusable functional test: `workflow_dispatch` (run as needed) + auto on `pull_request` touching `mcp/**`. Builds the real image, runs the MCP server standalone (**no Beeper login needed**), and asserts the tool contract + guard matrix. `smoke-test.sh` can't cover this — it needs an interactive Beeper login.

## Test matrix (local, pre-push)
| Case | Expected | Result |
|---|---|---|
| no-token localhost `tools/list` | 200 | ✅ |
| `Origin: evil` | 403 | ✅ |
| `Host: evil` | 403 | ✅ |
| `Origin: localhost:3000` | 200 | ✅ |
| 12 MB body | 413 (was 200) | ✅ |
| token set, no/wrong auth | 401 | ✅ |
| token set, correct | 200 | ✅ |

CI replays this matrix inside the built image.

## Still open (validated, not fixed)
- **VNC `-nopw`** — needs the container X stack booted to verify a fix safely.
- **AppImage checksum** — supply-chain note.

## Notes
- Back-compat: unset env ⇒ prior behavior; `smoke-test.sh` still passes; stdio transport untouched.
- Docs: CHANGELOG `[Unreleased]`, `beeperbox.context.md` auth model, `docs/PRD-mcp-http-hardening.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)