### PR TITLE
Safe rolling releases: CI-gate publish + :latest/:previous fallback

### DIFF
--- a/.github/workflows/mcp-test.yml
+++ b/.github/workflows/mcp-test.yml
@@ -1,20 +1,13 @@
 name: mcp-test
 
-# Functional test for the MCP server (mcp/server.js) as it actually ships in
-# the image — without needing a logged-in Beeper account.
+# Functional test for the MCP server (mcp/server.js) as it ships in the image,
+# without a logged-in Beeper account. Builds the real image and runs the MCP
+# guard matrix (tool contract + auth/Host/Origin/body 200/403/413/401) via the
+# shared scripts/mcp-guard-check.sh — the same script release.yml uses as its
+# publish gate, so the PR test and the release gate can't drift.
 #
-# The full smoke test (scripts/smoke-test.sh) needs an interactive Beeper
-# login via noVNC to reach (healthy), so it can't run unattended. This job
-# instead builds the real image and runs ONLY the MCP server standalone
-# (`--entrypoint node /opt/mcp/server.js`), then replays an HTTP assertion
-# matrix. Everything the MCP HTTP transport does *before* it calls the Beeper
-# API — protocol dispatch, tools/list, and the auth / Host / Origin / body
-# guards — is exercised here. Tool calls that hit Beeper are out of scope
-# (they need a real account; that's what smoke-test.sh covers manually).
-#
-# Triggers:
-#   - workflow_dispatch  -> run on demand ("trigger as needed")
-#   - pull_request       -> auto-run when MCP-relevant files change
+# Triggers: workflow_dispatch (on demand) + pull_request on the files that
+# affect the built image or the check itself.
 on:
   workflow_dispatch:
   pull_request:
@@ -23,6 +16,7 @@ on:
       - 'Dockerfile'
       - 'entrypoint.sh'
       - 'docker-compose.yml'
+      - 'scripts/mcp-guard-check.sh'
       - '.github/workflows/mcp-test.yml'
 
 permissions:
@@ -38,9 +32,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # amd64 only: the MCP server is arch-independent Node logic, so there's
-      # no value in a QEMU arm64 build here. Load the image locally so we can
-      # `docker run` it. GHA cache is shared with release.yml's builds.
       - name: Build image (amd64, load locally)
         uses: docker/build-push-action@v7
         with:
@@ -51,87 +42,5 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Start MCP server — open mode (no MCP_AUTH_TOKEN)
-        run: |
-          docker run -d --name mcp-open -p 23375:23375 \
-            --entrypoint node beeperbox:mcp-test /opt/mcp/server.js
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null -X POST http://127.0.0.1:23375 \
-                 -d '{"jsonrpc":"2.0","id":0,"method":"tools/list"}'; then
-              echo "MCP server ready"; exit 0
-            fi
-            sleep 1
-          done
-          echo "MCP server did not become ready"; docker logs mcp-open; exit 1
-
-      - name: Assert MCP contract — all 10 tools present
-        run: |
-          # jq is preinstalled on ubuntu-latest; walk result.tools[].name by
-          # structure (a substring grep would false-positive on tool names that
-          # appear inside another tool's description).
-          names=$(curl -s -X POST http://127.0.0.1:23375 \
-            -H 'Content-Type: application/json' \
-            -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
-            | jq -r '.result.tools[].name')
-          fail=0
-          for t in list_accounts list_inbox list_unread get_chat read_chat \
-                   search_messages send_message note_to_self react_to_message archive_chat; do
-            if echo "$names" | grep -qx "$t"; then echo "PASS: $t present"; else echo "FAIL: $t missing"; fail=1; fi
-          done
-          exit $fail
-
-      - name: Assert hardening guard matrix — open mode
-        run: |
-          U=http://127.0.0.1:23375
-          fail=0
-          assert() { # desc expected actual
-            if [ "$2" = "$3" ]; then echo "PASS: $1 ($3)"; else echo "FAIL: $1 — expected $2 got $3"; fail=1; fi
-          }
-          code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
-          assert "no-token localhost tools/list -> 200 (back-compat)" 200 \
-            "$(code -X POST $U -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
-          assert "cross-origin (bad Origin) -> 403" 403 \
-            "$(code -X POST $U -H 'Origin: https://evil.example' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
-          assert "DNS-rebind (bad Host) -> 403" 403 \
-            "$(code -X POST $U -H 'Host: evil.example' -d '{"jsonrpc":"2.0","id":4,"method":"tools/list"}')"
-          assert "allowed Origin (localhost:3000) -> 200" 200 \
-            "$(code -X POST $U -H 'Origin: http://localhost:3000' -d '{"jsonrpc":"2.0","id":5,"method":"tools/list"}')"
-          { printf '{"jsonrpc":"2.0","id":6,"method":"tools/list","pad":"'; head -c 12000000 /dev/zero | tr '\0' 'A'; printf '"}'; } > /tmp/big.json
-          assert "12MB body -> 413 (body cap)" 413 \
-            "$(code -X POST $U -H 'Content-Type: application/json' --data-binary @/tmp/big.json)"
-          exit $fail
-
-      - name: Start MCP server — auth mode (MCP_AUTH_TOKEN set)
-        run: |
-          docker run -d --name mcp-auth -p 23376:23375 \
-            -e MCP_AUTH_TOKEN=ci-secret \
-            --entrypoint node beeperbox:mcp-test /opt/mcp/server.js
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null -X POST http://127.0.0.1:23376 \
-                 -H 'Authorization: Bearer ci-secret' \
-                 -d '{"jsonrpc":"2.0","id":0,"method":"tools/list"}'; then
-              echo "auth-mode MCP server ready"; exit 0
-            fi
-            sleep 1
-          done
-          echo "auth-mode MCP server did not become ready"; docker logs mcp-auth; exit 1
-
-      - name: Assert bearer-token enforcement
-        run: |
-          U=http://127.0.0.1:23376
-          fail=0
-          assert() { if [ "$2" = "$3" ]; then echo "PASS: $1 ($3)"; else echo "FAIL: $1 — expected $2 got $3"; fail=1; fi; }
-          code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
-          assert "no auth header -> 401" 401 \
-            "$(code -X POST $U -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')"
-          assert "wrong token -> 401" 401 \
-            "$(code -X POST $U -H 'Authorization: Bearer nope' -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
-          assert "correct token -> 200" 200 \
-            "$(code -X POST $U -H 'Authorization: Bearer ci-secret' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
-          exit $fail
-
-      - name: Dump container logs on failure
-        if: failure()
-        run: |
-          echo "=== mcp-open ==="; docker logs mcp-open 2>&1 | tail -50 || true
-          echo "=== mcp-auth ==="; docker logs mcp-auth 2>&1 | tail -50 || true
+      - name: MCP guard matrix
+        run: bash scripts/mcp-guard-check.sh beeperbox:mcp-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,20 +1,22 @@
 name: release
 
-# Builds the beeperbox image and publishes it to GHCR.
+# Builds the beeperbox image and publishes it to GHCR — gated on the same
+# functional tests the PRs run, so a broken build (or a broken upstream Beeper
+# pulled by the weekly rebuild) can't silently become :latest.
+#
+# Flow for the release path (tag push / weekly cron / manual dispatch):
+#   prepare  -> resolve which ref to build
+#   verify   -> build amd64, run the MCP + VNC guard checks (the gate)
+#   publish  -> roll current :latest to :previous, then build+push multi-arch
+#               semver tags + :latest  (only runs if verify passed)
+# If verify fails, publish is skipped: the previous :latest stays live as the
+# last-known-good image, :previous is untouched, and notify-failure flags it.
 #
 # Triggers:
-#   - tag push (v*.*.*)        -> :X.Y.Z, :X.Y, :X, :latest
-#   - push to master           -> :edge (bleeding-edge, may break)
-#   - weekly cron (Mon 06 UTC) -> rebuild newest release tag and re-push
-#                                 :X.Y.Z / :X.Y / :X / :latest so the
-#                                 bundled Beeper AppImage stays current
-#                                 without needing a new code release.
-#   - manual dispatch          -> ad-hoc rebuild of newest release tag
-#
-# Source lives in the repo; published artifacts live in GHCR. Users run
-# `docker compose up` against docker-compose.yml (which references the
-# published image) without cloning. Developers use docker-compose.dev.yml
-# to build from a local checkout.
+#   - tag push (v*.*.*)        -> :X.Y.Z, :X.Y, :X, :latest (gated)
+#   - weekly cron (Mon 06 UTC) -> rebuild newest release tag, refresh Beeper (gated)
+#   - manual dispatch          -> ad-hoc gated rebuild of newest release tag
+#   - push to master           -> :edge (bleeding-edge, ungated by design)
 
 on:
   push:
@@ -31,12 +33,14 @@ permissions:
   packages: write
 
 jobs:
-  # Tagged releases and scheduled rebuilds publish the semver tags + :latest.
-  # On schedule/dispatch we resolve the newest release tag and build from
-  # that ref, so :latest keeps pointing at released code (not master HEAD).
-  release:
+  # Resolve the ref to build. Tag push builds the pushed tag; schedule/dispatch
+  # resolve the newest release tag so :latest tracks released code, not master.
+  prepare:
     if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.ref.outputs.ref }}
+      skip: ${{ steps.ref.outputs.skip }}
     steps:
       - name: Resolve ref
         id: ref
@@ -54,44 +58,96 @@ jobs:
             echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
 
+  # The gate: build the candidate image and run the same checks the PRs run.
+  # Nothing here pushes to GHCR.
+  verify:
+    needs: prepare
+    if: needs.prepare.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
-        if: steps.ref.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.ref.outputs.ref }}
+          ref: ${{ needs.prepare.outputs.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build candidate (amd64, load locally)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: beeperbox:candidate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: MCP guard gate
+        run: bash scripts/mcp-guard-check.sh beeperbox:candidate
+
+      - name: Install Xvfb + x11vnc
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb x11vnc
+
+      - name: VNC auth gate
+        run: |
+          bash -n entrypoint.sh
+          if ! grep -q 'VNC_PASSWORD' entrypoint.sh \
+             || ! grep -q -- '-rfbauth' entrypoint.sh \
+             || ! grep -q -- '-nopw' entrypoint.sh; then
+            echo "entrypoint.sh lost its VNC auth wiring"; exit 1
+          fi
+          bash scripts/vnc-auth-check.sh
+
+  # Publish only runs if verify passed. Rolls the current :latest to :previous
+  # for a known-good fallback, then builds + pushes the multi-arch image.
+  publish:
+    needs: [prepare, verify]
+    if: needs.prepare.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare.outputs.ref }}
 
       - name: Set up QEMU
-        if: steps.ref.outputs.skip != 'true'
         uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
-        if: steps.ref.outputs.skip != 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        if: steps.ref.outputs.skip != 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Roll current :latest -> :previous (known-good fallback)
+        run: |
+          IMG=ghcr.io/${{ github.repository_owner }}/beeperbox
+          if docker buildx imagetools inspect "$IMG:latest" >/dev/null 2>&1; then
+            docker buildx imagetools create -t "$IMG:previous" "$IMG:latest"
+            echo "rolled $IMG:latest -> $IMG:previous"
+          else
+            echo "no existing :latest yet — skipping :previous roll (first publish)"
+          fi
+
       - name: Compute image tags
-        if: steps.ref.outputs.skip != 'true'
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/beeperbox
           tags: |
-            type=semver,pattern={{version}},value=${{ steps.ref.outputs.ref }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ steps.ref.outputs.ref }}
-            type=semver,pattern={{major}},value=${{ steps.ref.outputs.ref }}
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.ref }}
+            type=semver,pattern={{major}},value=${{ needs.prepare.outputs.ref }}
             type=raw,value=latest
 
       - name: Build and push
-        if: steps.ref.outputs.skip != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -102,8 +158,25 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # Every push to master publishes :edge. Bleeding-edge, may break between
-  # releases. Users opt in explicitly.
+  # Flags a failed gate/publish loudly. :latest is unchanged on failure, so
+  # this is "we did NOT ship", not "we shipped something broken".
+  notify-failure:
+    needs: [prepare, verify, publish]
+    if: failure() && needs.prepare.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize
+        run: |
+          {
+            echo "## ⚠️ Release gate failed — \`:latest\` was NOT updated"
+            echo ""
+            echo "Ref: \`${{ needs.prepare.outputs.ref }}\`"
+            echo ""
+            echo "The verify (guard tests) or publish step failed. The previous \`:latest\` remains the live image and \`:previous\` is unchanged — nothing broken was shipped. Investigate the failing job before re-running."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Every push to master publishes :edge — bleeding-edge, may break between
+  # releases, ungated by design. Users opt in explicitly.
   edge:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -126,11 +199,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Compute OCI labels (including org.opencontainers.image.revision)
-      # so `docker inspect ghcr.io/.../beeperbox:edge` shows which master
-      # commit the image was built from. Without metadata-action the labels
-      # are empty — :latest has them because its job runs metadata-action,
-      # :edge needs the same.
       - name: Compute OCI labels
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/vnc-test.yml
+++ b/.github/workflows/vnc-test.yml
@@ -1,20 +1,19 @@
 name: vnc-test
 
-# Verifies the noVNC/x11vnc auth posture configured by entrypoint.sh, without
+# Verifies the noVNC/x11vnc auth posture configured by entrypoint.sh without
 # booting the full container: VNC_PASSWORD unset -> RFB security type None (1);
-# VNC_PASSWORD set -> VNC authentication (2) and NOT None. This mirrors
-# entrypoint.sh's x11vnc invocation; the grep guard below fails if that wiring
-# is ever removed, so the functional probe and the source can't silently drift.
+# set -> VNC authentication (2), not None. Runs the shared
+# scripts/vnc-auth-check.sh (also used by release.yml's publish gate). The grep
+# guard fails if entrypoint.sh ever loses the VNC_PASSWORD/-rfbauth/-nopw wiring.
 #
-# Triggers:
-#   - workflow_dispatch  -> run on demand ("trigger as needed")
-#   - pull_request       -> auto-run when the relevant files change
+# Triggers: workflow_dispatch (on demand) + pull_request on the relevant files.
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - 'entrypoint.sh'
       - 'scripts/vnc-auth-probe.py'
+      - 'scripts/vnc-auth-check.sh'
       - '.github/workflows/vnc-test.yml'
 
 permissions:
@@ -38,23 +37,5 @@ jobs:
       - name: Install Xvfb + x11vnc
         run: sudo apt-get update -qq && sudo apt-get install -y -qq xvfb x11vnc
 
-      - name: Probe RFB security types (both modes)
-        run: |
-          export DISPLAY=:99
-          Xvfb :99 -screen 0 1024x768x24 -ac >/dev/null 2>&1 &
-          sleep 2
-          # open mode (VNC_PASSWORD unset) -> -nopw
-          x11vnc -display :99 -forever -nopw -shared -rfbport 5900 >/dev/null 2>&1 &
-          sleep 2
-          nopw=$(python3 scripts/vnc-auth-probe.py 127.0.0.1 5900)
-          # password mode -> -rfbauth (same commands entrypoint.sh runs)
-          x11vnc -storepasswd hunter2 /tmp/.vncpass >/dev/null 2>&1
-          x11vnc -display :99 -forever -rfbauth /tmp/.vncpass -shared -rfbport 5901 >/dev/null 2>&1 &
-          sleep 2
-          pw=$(python3 scripts/vnc-auth-probe.py 127.0.0.1 5901)
-          echo "nopw security types=[$nopw]   pw security types=[$pw]"
-          fail=0
-          echo "$nopw" | grep -qw 1 && echo "PASS: open mode offers None(1)"     || { echo "FAIL: open mode should offer 1"; fail=1; }
-          echo "$pw"   | grep -qw 2 && echo "PASS: password offers VNCAuth(2)"   || { echo "FAIL: password should offer 2"; fail=1; }
-          if echo "$pw" | grep -qw 1; then echo "FAIL: password mode must NOT offer None(1)"; fail=1; else echo "PASS: password mode does not offer None"; fi
-          exit $fail
+      - name: VNC auth probe
+        run: bash scripts/vnc-auth-check.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Published tags on GHCR: `:X.Y.Z` (exact, immutable), `:X.Y` (rolling within a mi
 
 ## [Unreleased]
 
+### CI / release
+- **Releases are now gated on the guard tests.** The publish path (tag push, weekly cron, manual dispatch) builds the image, runs the MCP guard matrix (`scripts/mcp-guard-check.sh`) and the VNC auth probe (`scripts/vnc-auth-check.sh`) against it, and **only pushes `:latest`/semver tags if they pass**. Closes the gap where the weekly rebuild could publish an untested `:latest` — e.g. if an auto-pulled newer Beeper broke startup. On failure the publish is skipped (previous `:latest` stays live as last-known-good) and the run is flagged in its summary.
+- **Rolling known-good fallback.** Each successful publish first rolls the current `:latest` to `:previous` (a server-side manifest copy, no rebuild). If a future `:latest` ever misbehaves, `BEEPERBOX_IMAGE_TAG=previous docker compose up -d` drops back to the prior image without needing to know the version number. For a bit-exact pin, use the image **digest** (`@sha256:…`) — semver tags are rebuilt by the weekly cron and are not immutable while they're the newest release.
+- **Shared test scripts** (`scripts/mcp-guard-check.sh`, `scripts/vnc-auth-check.sh`) are now the single source of truth for both the PR workflows (`mcp-test`, `vnc-test`) and the release gate, so "what the PR tests" and "what blocks a release" can't drift.
+- **Known limitation (unchanged):** the gate runs the MCP server standalone (no live Beeper account), so it catches build/startup/guard regressions but **not** Beeper API-shape drift breaking the normalizers. `:previous` is the safety net for that case. `:edge` (master pushes) stays ungated by design.
+
 ### Planned
 - Whatever the first real user issue asks for.
 

--- a/beeperbox.context.md
+++ b/beeperbox.context.md
@@ -459,6 +459,8 @@ beeperbox v0.4.x is a POC → early product. Real-world usage notes:
 | `0.2.0` | `4.2.715` | `2025-03-26` | `linux/amd64` |
 | `0.1.0` | `4.2.715` | — | `linux/amd64` |
 
+Published tags: `:latest` (newest release, rebuilt weekly and **test-gated** — a build that fails the MCP/VNC guard checks is not published), `:previous` (the prior `:latest`, kept as a known-good fallback — `BEEPERBOX_IMAGE_TAG=previous` to roll back), `:X.Y.Z` (a release; note it is re-pushed by the weekly cron while it's the newest, so it is *not* immutable). For a bit-exact, frozen image, pin the **digest** (`ghcr.io/hamr0/beeperbox@sha256:…`).
+
 Beeper Desktop is frozen at build time in the image. Rebuilding with `docker compose build --no-cache` pulls whatever Beeper Desktop is current at that moment. API schema changes in newer Beeper versions may break normalizers — open an issue if you hit one. For a reproducible, hash-verified build, pass `--build-arg BEEPER_VERSION=<ver> --build-arg BEEPER_SHA256=<sha256>`; without them the build auto-updates to the latest stable Beeper (the default).
 
 Starting with v0.3.0, `docker pull ghcr.io/hamr0/beeperbox:latest` gives you the variant that matches your CPU architecture automatically. Supported hosts: any amd64 Linux (x86/x64) or arm64 Linux (Raspberry Pi 4/5 64-bit, Oracle Cloud Ampere A1, Hetzner CAX-series, AWS Graviton, Apple Silicon under Docker Desktop). No `linux/arm/v7` — Beeper doesn't publish a 32-bit ARM AppImage, so 32-bit Pi OS installs need to upgrade to 64-bit.

--- a/scripts/mcp-guard-check.sh
+++ b/scripts/mcp-guard-check.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# mcp-guard-check.sh <image_ref>
+#
+# Boots the MCP server from <image_ref> in two modes — open (no auth) and
+# token-required — and asserts the tool contract plus the HTTP hardening
+# guard matrix (200/403/413/401). Exits non-zero on any failure.
+#
+# Single source of truth for the MCP gate: used by mcp-test.yml (PR/dispatch)
+# AND release.yml's publish gate, so "what the PR tests" and "what blocks a
+# release" are identical. Needs docker, curl, jq.
+set -u
+
+IMAGE="${1:?usage: mcp-guard-check.sh <image_ref>}"
+OPEN=mcp-guard-open
+AUTH=mcp-guard-auth
+fail=0
+
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { docker rm -f "$OPEN" "$AUTH" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+chk() { # desc expected actual
+  if [ "$2" = "$3" ]; then echo "PASS: $1 ($3)"; else echo "FAIL: $1 — expected $2 got $3"; fail=1; fi
+}
+code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+wait_ready() { # url [extra curl args...]
+  local url=$1; shift
+  for _ in $(seq 1 30); do
+    if curl -sf -o /dev/null -X POST "$url" "$@" -d '{"jsonrpc":"2.0","id":0,"method":"tools/list"}'; then return 0; fi
+    sleep 1
+  done
+  return 1
+}
+
+# ── open mode ─────────────────────────────────────────────────────
+docker run -d --name "$OPEN" -p 23375:23375 --entrypoint node "$IMAGE" /opt/mcp/server.js >/dev/null
+wait_ready http://127.0.0.1:23375 || { echo "FAIL: open server never became ready"; docker logs "$OPEN"; exit 1; }
+U=http://127.0.0.1:23375
+
+names=$(curl -s -X POST "$U" -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq -r '.result.tools[].name')
+for t in list_accounts list_inbox list_unread get_chat read_chat \
+         search_messages send_message note_to_self react_to_message archive_chat; do
+  if echo "$names" | grep -qx "$t"; then echo "PASS: tool $t present"; else echo "FAIL: tool $t missing"; fail=1; fi
+done
+
+chk "no-token tools/list -> 200 (back-compat)" 200 \
+  "$(code -X POST "$U" -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
+chk "cross-origin (bad Origin) -> 403" 403 \
+  "$(code -X POST "$U" -H 'Origin: https://evil.example' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
+chk "DNS-rebind (bad Host) -> 403" 403 \
+  "$(code -X POST "$U" -H 'Host: evil.example' -d '{"jsonrpc":"2.0","id":4,"method":"tools/list"}')"
+chk "allowed Origin -> 200" 200 \
+  "$(code -X POST "$U" -H 'Origin: http://localhost:3000' -d '{"jsonrpc":"2.0","id":5,"method":"tools/list"}')"
+{ printf '{"jsonrpc":"2.0","id":6,"method":"tools/list","pad":"'; head -c 12000000 /dev/zero | tr '\0' 'A'; printf '"}'; } > /tmp/mcp-big.json
+chk "12MB body -> 413 (body cap)" 413 \
+  "$(code -X POST "$U" -H 'Content-Type: application/json' --data-binary @/tmp/mcp-big.json)"
+
+# ── auth mode ─────────────────────────────────────────────────────
+docker run -d --name "$AUTH" -p 23376:23375 -e MCP_AUTH_TOKEN=ci-secret \
+  --entrypoint node "$IMAGE" /opt/mcp/server.js >/dev/null
+wait_ready http://127.0.0.1:23376 -H 'Authorization: Bearer ci-secret' \
+  || { echo "FAIL: auth server never became ready"; docker logs "$AUTH"; exit 1; }
+A=http://127.0.0.1:23376
+chk "no auth header -> 401" 401 \
+  "$(code -X POST "$A" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')"
+chk "wrong token -> 401" 401 \
+  "$(code -X POST "$A" -H 'Authorization: Bearer nope' -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}')"
+chk "correct token -> 200" 200 \
+  "$(code -X POST "$A" -H 'Authorization: Bearer ci-secret' -d '{"jsonrpc":"2.0","id":3,"method":"tools/list"}')"
+
+if [ "$fail" -eq 0 ]; then echo "=== MCP GUARD CHECK PASSED ==="; else echo "=== MCP GUARD CHECK FAILED ==="; fi
+exit "$fail"

--- a/scripts/vnc-auth-check.sh
+++ b/scripts/vnc-auth-check.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# vnc-auth-check.sh
+#
+# Asserts the x11vnc auth posture wired by entrypoint.sh: with no password
+# x11vnc offers RFB security type None (1); with -rfbauth it offers VNC
+# authentication (2) and NOT None. Exits non-zero on any failure.
+#
+# Single source of truth for the VNC gate: used by vnc-test.yml (PR/dispatch)
+# AND release.yml's publish gate. Needs Xvfb, x11vnc, python3, and
+# vnc-auth-probe.py alongside this script.
+set -u
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+export DISPLAY=:99
+fail=0
+
+Xvfb :99 -screen 0 1024x768x24 -ac >/dev/null 2>&1 &
+sleep 2
+
+# open mode (mirrors entrypoint.sh with VNC_PASSWORD unset)
+x11vnc -display :99 -forever -nopw -shared -rfbport 5900 >/dev/null 2>&1 &
+sleep 2
+nopw=$(python3 "$HERE/vnc-auth-probe.py" 127.0.0.1 5900)
+
+# password mode (mirrors entrypoint.sh with VNC_PASSWORD set)
+x11vnc -storepasswd ci-vnc-pass /tmp/.vncpass >/dev/null 2>&1
+x11vnc -display :99 -forever -rfbauth /tmp/.vncpass -shared -rfbport 5901 >/dev/null 2>&1 &
+sleep 2
+pw=$(python3 "$HERE/vnc-auth-probe.py" 127.0.0.1 5901)
+
+echo "nopw security types=[$nopw]   pw security types=[$pw]"
+if echo "$nopw" | grep -qw 1; then echo "PASS: open mode offers None(1)";   else echo "FAIL: open mode should offer 1"; fail=1; fi
+if echo "$pw"   | grep -qw 2; then echo "PASS: password offers VNCAuth(2)"; else echo "FAIL: password should offer 2"; fail=1; fi
+if echo "$pw"   | grep -qw 1; then echo "FAIL: password mode must NOT offer None(1)"; fail=1; else echo "PASS: password mode does not offer None"; fi
+
+if [ "$fail" -eq 0 ]; then echo "=== VNC AUTH CHECK PASSED ==="; else echo "=== VNC AUTH CHECK FAILED ==="; fi
+exit "$fail"


### PR DESCRIPTION
Implements both agreed proposals so auto-update is *tested before it ships* and *recoverable if it slips*.

## 1. Test-gated publish (`release.yml`)
Restructured the release path (tag push / weekly cron / dispatch) into **prepare → verify → publish**:
- **verify** builds the image and runs the MCP guard matrix + VNC auth probe against it (the gate).
- **publish** runs only if verify passed: rolls `:latest`→`:previous`, then builds+pushes multi-arch.

Previously the weekly cron republished `:latest` **ungated** — a broken upstream Beeper could silently become `:latest`. Now a failed gate skips the publish (previous `:latest` stays live as last-known-good) and flags the run.

## 2. Rolling `:previous` fallback
Each publish first copies the current `:latest` to `:previous` (server-side, no rebuild). Recover a bad release with `BEEPERBOX_IMAGE_TAG=previous`. Digest pin remains the bit-exact anchor.

## DRY — shared check scripts
`scripts/mcp-guard-check.sh` + `scripts/vnc-auth-check.sh` are the single source of truth used by `mcp-test`, `vnc-test`, **and** the release gate — so the PR test and the release gate can't drift. `mcp-test`/`vnc-test` refactored to call them.

## Verified
- Both scripts pass **locally against the real `:0.5.0` image** (18/18 MCP) and in a `debian:12-slim` container (VNC).
- `actionlint` + `shellcheck` clean.
- This PR's `mcp-test` + `vnc-test` exercise the refactored workflows + scripts.
- `release.yml` itself only triggers on tag/cron/dispatch (not PRs); end-to-end verification is a post-merge `workflow_dispatch`.

## Notes / limitations
- Gate runs the MCP server standalone (no live Beeper) → catches build/startup/guard regressions, **not** Beeper API-shape drift breaking normalizers. `:previous` is the safety net there.
- `:edge` (master pushes) stays ungated by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)