### PR TITLE
docs: clarify PRD stdio example uses default container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Published tags on GHCR: `:X.Y.Z` (exact, immutable), `:X.Y` (rolling within a mi
 ### Docs
 - **Added `docs/PRD.md` — the comprehensive product grounding doc.** Promoted from the prior hardening-only PRD into a full product spec covering purpose, what beeperbox is and explicitly is *not* (non-goals: single-network bots, laptop humans, multi-tenancy, typed SDKs, npm, streaming, in-place auto-update), target users, architecture, the raw-API + 10-tool MCP surface, the security model, the distribution/release model, versioning, release history, roadmap, and known limitations — all grounded in the CHANGELOG and commit history. This is now the reference for what changes are in-scope.
 - **Removed `docs/PRD-mcp-http-hardening.md`** — folded into `docs/PRD.md` (§7 security model, §8 release model). The hardening detail is preserved; it's no longer a separate feature spec.
+- Clarified in `docs/PRD.md` §6.2 that the `docker exec -i beeperbox …` stdio example uses the *default* container name (`BEEPERBOX_CONTAINER_NAME`-overridable for multi-instance hosts).
 
 ### Planned
 - Whatever the first real user issue asks for.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -119,7 +119,7 @@ The full upstream `/v1/*` API, reachable on `:23373` with `Authorization: Bearer
 A single-file, zero-dependency Node server wrapping the raw API. Two interchangeable transports in one process, selected at startup:
 
 - **HTTP** (default, always on): JSON-RPC 2.0 over POST on `:23375`. For remote agents, cross-container setups, cloud runtimes.
-- **stdio** (on demand): newline-delimited JSON-RPC over stdin/stdout (stdout reserved for protocol, logs to stderr), via `docker exec -i beeperbox node /opt/mcp/server.js --stdio`. For local MCP clients (Claude Code, Cursor, Cline, Continue, bareagent).
+- **stdio** (on demand): newline-delimited JSON-RPC over stdin/stdout (stdout reserved for protocol, logs to stderr), via `docker exec -i beeperbox node /opt/mcp/server.js --stdio` (here `beeperbox` is the default container name — use your `BEEPERBOX_CONTAINER_NAME` if you overrode it for a multi-instance host). For local MCP clients (Claude Code, Cursor, Cline, Continue, bareagent).
 
 **The 10 tools:**
 


### PR DESCRIPTION
Trivial follow-up to #8 (caught in code review). The `docs/PRD.md` §6.2 stdio example hardcoded the default container name `beeperbox`; clarify it tracks `BEEPERBOX_CONTAINER_NAME` on multi-instance hosts. CHANGELOG noted.

Docs-only; no runtime, schema, or port change. Passed `/ship` (all code/service checks N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)