### PR TITLE
release: stamp v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ beeperbox follows [Semantic Versioning 2.0.0](https://semver.org/) with one conc
 
 Published tags on GHCR: `:X.Y.Z` (exact, immutable), `:X.Y` (rolling within a minor), `:X` (rolling within a major — always `:0` today), `:latest` (newest release tag, rebuilt weekly to pick up upstream Beeper AppImage drift), `:edge` (every push to `master`, may break).
 
-## [Unreleased]
+## [0.6.0] — 2026-06-15 `[MINOR]`
+
+First release driven end-to-end by a real consumer ([multis](https://github.com/hamr0/multis), beeperbox's first customer): a watch primitive and a reliable echo-guard so an agent can react to incoming messages without reinventing the seed/poll/dedup loop or echo-looping on its own sends, plus two container-lifecycle robustness fixes. MINOR per the versioning policy — new MCP tool + additive schema fields + new runtime behavior, all backward compatible. **Live-validation note:** the `source` echo-guard and the `pendingMessageID` → final-bridge-id resolution were validated against a real Beeper account by multis (CI has none); the standard release gate (guard + VNC probes) still runs the server standalone.
 
 ### Added — `poll_messages` watch primitive + echo-guard `[MINOR]`
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ curl -LO https://raw.githubusercontent.com/hamr0/beeperbox/master/docker-compose
 docker compose up -d
 ```
 
-Pulls the pre-built multi-arch image (`ghcr.io/hamr0/beeperbox:latest`, `linux/amd64` + `linux/arm64`). No clone, no build. Pin a version with `BEEPERBOX_IMAGE_TAG=0.5.0 docker compose up -d`, or track master with `:edge` (may break).
+Pulls the pre-built multi-arch image (`ghcr.io/hamr0/beeperbox:latest`, `linux/amd64` + `linux/arm64`). No clone, no build. Pin a version with `BEEPERBOX_IMAGE_TAG=0.6.0 docker compose up -d`, or track master with `:edge` (may break).
 
 **2. Log in once**
 

--- a/beeperbox.context.md
+++ b/beeperbox.context.md
@@ -1,7 +1,7 @@
 # beeperbox — Integration Guide
 
 > For AI assistants and developers wiring beeperbox into an agent project.
-> v0.5.0 | Docker (linux/amd64 + linux/arm64) + vanilla Node >= 18 | 0 runtime deps | Apache-2.0
+> v0.6.0 | Docker (linux/amd64 + linux/arm64) + vanilla Node >= 18 | 0 runtime deps | Apache-2.0
 >
 > Full human setup walkthrough (noVNC login, token creation, `.env` file, troubleshooting): [docs/GUIDE.md](docs/GUIDE.md)
 
@@ -546,7 +546,7 @@ beeperbox v0.4.x is a POC → early product. Real-world usage notes:
 
 | beeperbox | Beeper Desktop | MCP protocol | Architectures |
 |---|---|---|---|
-| `0.5.0` | latest at build time (`4.2.860`+, auto-updated) | `2025-03-26` | `linux/amd64`, `linux/arm64` |
+| `0.6.0` | latest at build time (`4.2.860`+, auto-updated) | `2025-03-26` | `linux/amd64`, `linux/arm64` |
 | `0.4.0` | `4.2.715` (built into image) | `2025-03-26` | `linux/amd64`, `linux/arm64` |
 | `0.3.3` | `4.2.715` (built into image) | `2025-03-26` | `linux/amd64`, `linux/arm64` |
 | `0.3.2` | `4.2.715` (built into image) | `2025-03-26` | `linux/amd64`, `linux/arm64` |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -3,7 +3,7 @@
 > **This is the grounding document for beeperbox: what it is, what it is *not*, and why.**
 > When a feature, a release, or a "wouldn't it be cool if…" idea is on the table, it gets measured against this doc. Anything that contradicts the "Non-goals" section is rejected by default unless this document is changed first.
 
-- **Status:** shipped and in use. Current release **v0.5.0** (2026-05-24); rolling changes tracked in [`CHANGELOG.md`](../CHANGELOG.md).
+- **Status:** shipped and in use. Current release **v0.6.0** (2026-06-15); rolling changes tracked in [`CHANGELOG.md`](../CHANGELOG.md).
 - **Distribution:** pre-built multi-arch image on GHCR — `ghcr.io/hamr0/beeperbox` (`linux/amd64` + `linux/arm64`).
 - **License:** [Apache-2.0](../LICENSE). Independent wrapper around Beeper Desktop; **no affiliation** with Beeper / Automattic.
 - **Related deep-dive docs:** [`GUIDE.md`](GUIDE.md) (human operator walkthrough), [`../beeperbox.context.md`](../beeperbox.context.md) (AI-assistant integration guide).
@@ -97,7 +97,7 @@ All three publish to `127.0.0.1` by design. Remote access is a deliberate opt-in
 | Var | Default | Effect |
 |---|---|---|
 | `BEEPER_TOKEN` | unset | Bearer token minted in Beeper Desktop; authenticates raw-API and MCP calls upstream. |
-| `BEEPERBOX_IMAGE_TAG` | `latest` | Which GHCR tag to run (`0.5.0`, `0.5`, `0`, `latest`, `previous`, `edge`, or a `@sha256:` digest). |
+| `BEEPERBOX_IMAGE_TAG` | `latest` | Which GHCR tag to run (`0.6.0`, `0.6`, `0`, `latest`, `previous`, `edge`, or a `@sha256:` digest). |
 | `BEEPERBOX_HOST_PORT` / `_NOVNC_PORT` / `_MCP_PORT` | `23373` / `6080` / `23375` | Host-side port remapping for multi-instance hosts. |
 | `BEEPERBOX_CONTAINER_NAME` | `beeperbox` | Container name, for running multiple instances. |
 | `MCP_AUTH_TOKEN` | unset | When set, every MCP HTTP request must carry `Authorization: Bearer <token>` or get `401`. |
@@ -239,7 +239,8 @@ beeperbox is a single-tenant container that holds a credential (`BEEPER_TOKEN`) 
 | 0.3.3 | 2026-05-13 | Fix black-VNC-on-boot (GPU) and IPv6-socat first-install bugs. |
 | 0.4.0 | 2026-05-18 | Deterministic `note_to_self` routing (off third-party saved-messages); clean SIGTERM shutdown; MCP smoke probe. |
 | 0.5.0 | 2026-05-24 | Security hardening: MCP auth + Host/Origin + body cap, VNC password, `no-new-privileges`, opt-in pinned builds. |
-| *(unreleased)* | — | CI-gated releases + `:previous` rollback; shared guard scripts as single source of truth. |
+| 0.5.1 | 2026-05-25 | CI-gated releases + `:previous` rollback; shared guard scripts as single source of truth. |
+| 0.6.0 | 2026-06-15 | `poll_messages` watch primitive + exact-id echo-guard (`source`/`client_tag`); supervised backend + restart-survivable display. |
 
 ---
 

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -919,7 +919,7 @@ async function handleRequest(req) {
       case 'initialize':
         result = {
           protocolVersion: '2025-03-26',
-          serverInfo: { name: 'beeperbox', version: '0.5.0' },
+          serverInfo: { name: 'beeperbox', version: '0.6.0' },
           capabilities: { tools: {} },
         };
         break;


### PR DESCRIPTION
Promotes `[Unreleased]` → **`## [0.6.0] — 2026-06-15`** so `:latest` carries Ask A/B before multis Phase 2 ships (Phase 2 drops `_isLooping` + the text-prefix hack and hard-depends on the exact-id echo-guard).

## Bundled in 0.6.0 (everything from `[Unreleased]`)
- `poll_messages` watch primitive + `source`/`client_tag` echo-guard (#11)
- `docker restart` stale-Xvfb-lock fix (#12)
- reliable echo via `pendingMessageID` → final-bridge-id resolution + supervised `beepertexts` (#13)

MINOR per the versioning policy: new MCP tool + additive schema fields + new runtime behavior, all backward compatible.

## Version stamps moved
- `mcp/server.js` — `serverInfo.version` `0.5.0` → `0.6.0` (was stale even at 0.5.1)
- `docs/PRD.md` — status → `v0.6.0`; **release-history table corrected** (the stale `(unreleased)` row was actually 0.5.1) + new 0.6.0 row; example tag bumped
- `beeperbox.context.md` / `README.md` — header/version-table stamps + pin example → `0.6.0`

## Release mechanics
Merging this is docs-only. The **`v0.6.0` tag** (pushed after merge) is what triggers `release.yml` to build the gated multi-arch image and publish `:0.6.0` / `:0.6` / `:0` / `:latest` (old `:latest` → `:previous`).

## Verification note
The `source` echo-guard and the id-resolution round-trip were validated against a real Beeper account by **multis**; CI has no account, so the standard release gate (MCP guard matrix + VNC probe) still runs the server standalone. 27/27 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)