### PR TITLE
docs(guide): fix stale version line (v0.4.x → v0.8.x)

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1093,7 +1093,7 @@ If you need those, put them in front of beeperbox (reverse proxy, governance mid
 - **WhatsApp on-device bridge** sometimes logs `no bridge event found` warnings during backup. Harmless, ignore.
 - **Multi-arch image**: `linux/amd64` and `linux/arm64` are published from v0.3.0 onward — Raspberry Pi 4/5, Apple-silicon Docker Desktop, and Oracle Cloud's free ARM tier all pull the right variant automatically.
 - **No streaming subscriptions in the API**: the Beeper Desktop API is request/response. For realtime updates you poll `/v1/chats` or hook into the Beeper Desktop MCP server (advanced).
-- **Pre-1.0**. Current line is v0.4.x — the MCP tool surface, HTTP API, default ports, and `Chat`/`Message` schemas are usable but not declared stable. See [CHANGELOG.md](../CHANGELOG.md) for the versioning policy and what each bump type guarantees. Running on a personal VPS for your own agents is fine; running as a shared service is not.
+- **Pre-1.0**. Current line is v0.8.x — the MCP tool surface, HTTP API, default ports, and `Chat`/`Message` schemas are usable but not declared stable. See [CHANGELOG.md](../CHANGELOG.md) for the versioning policy and what each bump type guarantees. Running on a personal VPS for your own agents is fine; running as a shared service is not.
 
 ---
 


### PR DESCRIPTION
GUIDE's 'Limits and caveats' still said the current line was v0.4.x (stale since 0.5.0). Bumped to v0.8.x to match the v0.8.0 release. Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)