### PR TITLE
release: v0.9.0 — account-sync resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ beeperbox follows [Semantic Versioning 2.0.0](https://semver.org/) with one conc
 
 Published tags on GHCR: `:X.Y.Z` (exact, immutable), `:X.Y` (rolling within a minor), `:X` (rolling within a major — always `:0` today), `:latest` (newest release tag, rebuilt weekly to pick up upstream Beeper AppImage drift), `:edge` (every push to `master`, may break).
 
-## [Unreleased]
+## [0.9.0] — 2026-06-20 `[MINOR]`
 
-Account-sync resilience + observability — filed by [multis](https://github.com/hamr0/multis) after a WhatsApp account added via noVNC didn't surface, and a plain `docker restart` didn't recover it (it self-corrected only later). MINOR-bound when released: `list_accounts` gains a new `status` schema field (new runtime behavior per the versioning policy).
+Account-sync resilience + observability — filed by [multis](https://github.com/hamr0/multis) after a WhatsApp account added via noVNC didn't surface, and a plain `docker restart` didn't recover it (it self-corrected only later). MINOR per the versioning policy: `list_accounts` gains a new `status` schema field (new runtime behavior). No tool was added or removed — the verb set is still the 12 documented tools; this changes one tool's output shape and the runtime's caching behavior.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Not a thin proxy over Beeper's raw API — an **opinionated 12-tool verb layer**
 
 | Tool | What it does |
 |---|---|
-| `list_accounts` | Which networks are connected (WhatsApp, Telegram, Discord …) — slug + label + display name |
+| `list_accounts` | Which networks are connected (WhatsApp, Telegram, Discord …) — slug + label + connection `status` + display name |
 | `list_inbox` | Most recently active chats, with unread counts and last-activity time |
 | `list_unread` | The "what needs me right now?" view — only chats with `unread_count > 0` |
 | `get_chat` | One chat's current metadata by ID |

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beeperbox",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Lite mode for beeperbox — the opinionated MCP verb server for Beeper Desktop, run standalone against a Beeper you already have open (no Docker, no Electron). The full headless-Beeper-in-Docker build lives at github.com/hamr0/beeperbox.",
   "bin": {
     "beeperbox": "server.js"

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1228,8 +1228,7 @@ async function preflight() {
     return;
   }
   try {
-    const accounts = await beeperFetch('/v1/accounts', { timeoutMs: PREFLIGHT_TIMEOUT_MS });
-    const list = Array.isArray(accounts) ? accounts : (accounts?.items || []);
+    const list = accountList(await beeperFetch('/v1/accounts', { timeoutMs: PREFLIGHT_TIMEOUT_MS }));
     say(`preflight OK: ${BEEPER_API} reachable, token accepted, ${list.length} account(s)`);
   } catch (e) {
     say(`preflight FAIL: ${BEEPER_API} unreachable or token rejected — ${e.message}`);


### PR DESCRIPTION
Cuts **v0.9.0** (MINOR) — ships the account-sync resilience fix (#22) and a small diff-review cleanup.

## Included
- **#22** account-sync resilience: bounded account-map cache (`BEEPERBOX_ACCOUNT_CACHE_TTL_MS`, never-cache-empty), `list_accounts` surfaces backend `status`, zero-account stderr observability.
- **diff-review cleanup:** preflight now uses the shared `accountList()` helper (one shape-parse; behavior-identical).

## Release stamp
- `mcp/package.json` `0.8.1` → `0.9.0` (npm == container == `serverInfo.version`)
- CHANGELOG `[Unreleased]` → `[0.9.0]` 2026-06-20 `[MINOR]`
- README: `list_accounts` line notes the new `status`

## Why MINOR
New `status` schema field on `list_accounts` = new runtime behavior. Verb set unchanged (still 12 tools).

## Verification
- 48/48 unit tests green (incl. version-parity + 12-verb set).
- `/security`: no Critical/High/Medium; `.env` untracked + gitignored, no secrets in history. Two Low/by-design notes (pre-existing proto-key write from trusted source; empty-not-cached re-fetch).
- Live-validated (#22): `list_accounts` returns `status` for all 5 accounts; `list_inbox` 0 unknown-network chats.

After merge: tag `v0.9.0` (→ release.yml GHCR rebuild) + `gh workflow run publish.yml` (→ npm 0.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)